### PR TITLE
Unified navbar and footer colors and typo fix.

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -15,8 +15,24 @@ body {
    background-repeat: no-repeat;
    } */
 
-.navbar-brand-nopad{display:inline-block;padding-top:0rem;padding-bottom:0rem;margin-right:1rem;font-size:1.25rem;line-height:inherit;white-space:nowrap}
-.unique-color-kipoi{background-color:#34669A!important}
+
+.navbar-brand-nopad {
+    display: inline-block;
+    padding-top: 0rem;
+    padding-bottom: 0rem;
+    margin-right: 1rem;
+    font-size: 1.25rem;
+    line-height: inherit;
+    white-space: nowrap
+}
+
+.main-content {
+    padding-top: 64px;
+}
+
+.unique-color-kipoi, .unique-color {
+    background-color: #34669a !important;
+}
 
 .left-margin{
   margin-left:1rem;
@@ -100,7 +116,7 @@ div.dataTables_wrapper div.dataTables_filter input {
 }
 
 .mdl-button--raised {
-  background: #33597e !important;
+  background: #34669a !important;
 }
 
 .nav-title-link {
@@ -224,10 +240,12 @@ hr.clearfix {
 
 /* Footer */
 footer.page-footer {
-  background-color: #4c5568;
-  margin-top: 2rem;
+    margin-top: 2rem;
 }
 
+footer.page-footer .footer-copyright {
+    margin-top: 20px;
+}
 /* body { */
 /* Margin bottom by footer height */
 /* margin-bottom: 232px; */

--- a/app/templates/footer.html
+++ b/app/templates/footer.html
@@ -14,7 +14,7 @@
               <h5 class="title mb-3"><strong>Useful links</strong></h5>
               <ul>
                 <li>
-                  <a href="https://github.com/kipoi/kipoi">API repository<i class="fa fa-github" aria-hidden="true"></i></a>
+                  <a href="https://github.com/kipoi/kipoi">API repository <i class="fa fa-github" aria-hidden="true"></i></a>
                 </li>
                 <li>
                   <a href="https://github.com/kipoi/models">Model repository <i class="fa fa-github" aria-hidden="true"></i></a>


### PR DESCRIPTION
Addressing issue #53.

Footer and navbar are now unified, along with the button for table pagination.

Note that normal practice is that main footer part has the same bg color as navbar while copyright part is a bit darker. In this case, just 20% opacity of black on top the footer color.

![image](https://user-images.githubusercontent.com/737315/37457169-7d585478-2841-11e8-946a-75b6b87be96f.png)
