### PR TITLE
CI fixed

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -55,9 +55,16 @@ def parse_schema(schema):
     elif isinstance(schema, dict):
         schema_list = []
         for key, value in schema.items():
-            value = value.get_config()
-            value["name"] = key
-            schema_list.append(value)
+            if isinstance(value, dict):
+                for name_of_schema_in_value, schema_in_value in value.items():
+                    if isinstance(schema_in_value, kipoi.components.ArraySchema):
+                        schema_in_value = schema_in_value.get_config()
+                        schema_in_value["name"] = name_of_schema_in_value
+                        schema_list.append(schema_in_value)
+            else:
+                value = value.get_config()
+                value["name"] = key
+                schema_list.append(value)
         return {"list": schema_list,
                 "type": "Dictionary of numpy arrays"}
 


### PR DESCRIPTION
The error was originating from schemas like the following -
```
schema=OrderedDict([('seq', OrderedDict([('acceptor_intron', ArraySchema(shape=(None, 4), doc='alternative sequence of acceptor intron', name='acceptor_intron', special_type=<ArraySpecialType.DNASeq: 'DNASeq'>, associated_metadata=[], column_labels=None)), ('acceptor', ArraySchema(shape=(None, 4), doc='alternative sequence of acceptor', name='acceptor', special_type=<ArraySpecialType.DNASeq: 'DNASeq'>, associated_metadata=[], column_labels=None)), ('exon', ArraySchema(shape=(None, 4), doc='alternative sequence of exon', name='exon', special_type=<ArraySpecialType.DNASeq: 'DNASeq'>, associated_metadata=[], column_labels=None)), ('donor', ArraySchema(shape=(None, 4), doc='alternative sequence of donor', name='donor', special_type=<ArraySpecialType.DNASeq: 'DNASeq'>, associated_metadata=[], column_labels=None)), ('donor_intron', ArraySchema(shape=(None, 4), doc='alternative sequence of donor intron', name='donor_intron', special_type=<ArraySpecialType.DNASeq: 'DNASeq'>, associated_metadata=[], column_labels=None))])), ('mut_seq', OrderedDict([('acceptor_intron', ArraySchema(shape=(None, 4), doc='alternative sequence of acceptor intron', name='acceptor_intron', special_type=<ArraySpecialType.DNASeq: 'DNASeq'>, associated_metadata=[], column_labels=None)), ('acceptor', ArraySchema(shape=(None, 4), doc='alternative sequence of acceptor', name='acceptor', special_type=<ArraySpecialType.DNASeq: 'DNASeq'>, associated_metadata=[], column_labels=None)), ('exon', ArraySchema(shape=(None, 4), doc='alternative sequence of exon', name='exon', special_type=<ArraySpecialType.DNASeq: 'DNASeq'>, associated_metadata=[], column_labels=None)), ('donor', ArraySchema(shape=(None, 4), doc='alternative sequence of donor', name='donor', special_type=<ArraySpecialType.DNASeq: 'DNASeq'>, associated_metadata=[], column_labels=None)), ('donor_intron', ArraySchema(shape=(None, 4), doc='alternative sequence of donor intron', name='donor_intron', special_type=<ArraySpecialType.DNASeq: 'DNASeq'>, associated_metadata=[], column_labels=None))]))]), key=seq, value=OrderedDict([('acceptor_intron', ArraySchema(shape=(None, 4), doc='alternative sequence of acceptor intron', name='acceptor_intron', special_type=<ArraySpecialType.DNASeq: 'DNASeq'>, associated_metadata=[], column_labels=None)), ('acceptor', ArraySchema(shape=(None, 4), doc='alternative sequence of acceptor', name='acceptor', special_type=<ArraySpecialType.DNASeq: 'DNASeq'>, associated_metadata=[], column_labels=None)), ('exon', ArraySchema(shape=(None, 4), doc='alternative sequence of exon', name='exon', special_type=<ArraySpecialType.DNASeq: 'DNASeq'>, associated_metadata=[], column_labels=None)), ('donor', ArraySchema(shape=(None, 4), doc='alternative sequence of donor', name='donor', special_type=<ArraySpecialType.DNASeq: 'DNASeq'>, associated_metadata=[], column_labels=None)), ('donor_intron', ArraySchema(shape=(None, 4), doc='alternative sequence of donor intron', name='donor_intron', special_type=<ArraySpecialType.DNASeq: 'DNASeq'>, associated_metadata=[], column_labels=None))])
```

Am I correct in assuming intended name of the schemas should be 'acceptor_intron', 'donor_intron' etc instead of 'seq' or 'mut_seq'?