### PR TITLE
Fix ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,6 @@ jobs:
     working_directory: ~/repo
     steps:
       - checkout
-      - *update_conda
       - *install_kipoi
       - *install_kipoiseq_deps
       - *install_kipoiseq
@@ -75,7 +74,6 @@ jobs:
           fingerprints:
             - 60:0f:05:31:12:3d:bc:8b:df:9d:08:da:71:a5:43:b6
       - checkout
-      - *update_conda
       - *install_kipoi
       - *install_kipoiseq_deps
       - *install_kipoiseq

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,6 @@
 version: 2
 
 variables:
-  update_conda: &update_conda
-    run:
-      name: Update conda
-      command: conda update --yes conda
   install_kipoiseq_deps: &install_kipoiseq_deps
     run:
       name: Install Kipoiseq conda dependencies

--- a/README.md
+++ b/README.md
@@ -19,18 +19,26 @@ $ make serve
 
 ## Pre-requirements
 
+### Virtual python environment with python 3.6
+
+Create a conda (or as per your choice) virtual environment using python 3.6. This is important since for kipoi, 3.6 is the highest maintained version as of now.
+
+```bash
+conda create -n websiteenv python=3.6
+```
+
 ### Kipoi
 
-Install Kipoi package by following installation process from <https://github.com/kipoi/kipoi>.
+Install Kipoi package by following installation process from [here](https://github.com/kipoi/kipoi) and kipoiseq from [here](https://github.com/kipoi/kipoiseq).
 
 ## Requirements
 
-All python requirements are listed in `requirements.txt` file.
+All python requirements are listed in `app/requirements.txt` file.
 
 Installation of python requirements:
 
 ```bash
-pip3 install -r requirements.txt
+pip3 install -r app/requirements.txt
 ```
 
 To speed-up operations like `kipoi.get_source("kipoi").list_models` or `kipoi.get_source("kipoi").list_models_by_group()` that internally trigger `git pull` on kipoi project, we use __memcached__ service to cache results for the duration set in `config.py` under `CACHE_DURATION` entry.


### PR DESCRIPTION
Fixed ci. 
I had to remove update of conda which uses python 3.9 as the default version. Kipoi can not be installed with python 3.9. 
I also updated README